### PR TITLE
[AIRFLOW-908] Print hostname at the start of cli run

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -19,6 +19,7 @@ import logging
 import reprlib
 
 import os
+import socket
 import subprocess
 import textwrap
 import warnings
@@ -383,6 +384,9 @@ def run(args, dag=None):
             filename=filename,
             level=settings.LOGGING_LEVEL,
             format=settings.LOG_FORMAT)
+
+    hostname = socket.getfqdn()
+    logging.info("Running on host {}".format(hostname))
 
     if not args.pickle and not dag:
         dag = get_dag(args)


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow 908](https://issues.apache.org/jira/browse/AIRFLOW-908) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-XXX


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
This PR adds functionality to print hostname at the start of cli run to log.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
No testing for logging.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

@aoen @saguziel 