### PR TITLE
[AIRFLOW-936] Add clear/mark success for all tasks in a dagrun in the UI

### DIFF
--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -216,6 +216,36 @@
       </div>
     </div>
   </div>
+  <!-- Modal for dag -->
+  <div class="modal fade" id="dagModal"
+        tabindex="-1" role="dialog"
+      aria-labelledby="dagModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h4 class="modal-title" id="dagModalLabel">
+            <span id='dag_id'></span>
+          </h4>
+        </div>
+        <div class="modal-body">
+          <button id="btn_edit_dag" type="button" class="btn btn-primary">
+            Edit DAG Run
+          </button>
+          <button id="btn_dag_clear" type="button" class="btn btn-primary">
+            Clear DAG
+          </button>
+          <button id="btn_dag_success" type="button" class="btn btn-primary">
+            Mark DAG Success
+          </button>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-default" data-dismiss="modal">
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
 {% endblock %}
 {% block tail %}
   {{ lib.form_js() }}
@@ -239,6 +269,7 @@ function updateQueryStringParameter(uri, key, value) {
       $('.never_active').removeClass('active');
     });
 
+    var id = '';
     var dag_id = '{{ dag.dag_id }}';
     var task_id = '';
     var exection_date = '';
@@ -261,6 +292,14 @@ function updateQueryStringParameter(uri, key, value) {
             $("#div_btn_subdag").show();
             subdag_id = "{{ dag.dag_id }}."+t;
         }
+    }
+
+    function call_modal_dag(dag) {
+      id = dag && dag.id;
+      execution_date = dag && dag.execution_date;
+      $('#dag_id').html(dag_id);
+      $('#dagModal').modal({});
+      $("#dagModal").css("margin-top","0px");
     }
 
     $("#btn_rendered").click(function(){
@@ -328,6 +367,21 @@ function updateQueryStringParameter(uri, key, value) {
       window.location = url;
     });
 
+    $("#btn_dag_clear").click(function(){
+      url = "{{ url_for('airflow.clear') }}" +
+        "?task_id=" + encodeURIComponent(task_id) +
+        "&clear_all=true" +
+        "&dag_id=" + encodeURIComponent(dag_id) +
+        "&future=" + $('#btn_future').hasClass('active') +
+        "&past=" + $('#btn_past').hasClass('active') +
+        "&upstream=" + $('#btn_upstream').hasClass('active') +
+        "&downstream=" + $('#btn_downstream').hasClass('active') +
+        "&recursive=" + $('#btn_recursive').hasClass('active') +
+        "&execution_date=" + execution_date +
+        "&origin=" + encodeURIComponent(window.location);
+      window.location = url;
+    });
+
     $("#btn_success").click(function(){
       url = "{{ url_for('airflow.success') }}" +
         "?task_id=" + encodeURIComponent(task_id) +
@@ -336,6 +390,15 @@ function updateQueryStringParameter(uri, key, value) {
         "&downstream=" + $('#btn_success_downstream').hasClass('active') +
         "&future=" + $('#btn_success_future').hasClass('active') +
         "&past=" + $('#btn_success_past').hasClass('active') +
+        "&execution_date=" + execution_date +
+        "&origin=" + encodeURIComponent(window.location);
+
+      window.location = url;
+    });
+
+    $('#btn_dag_success').click(function(){
+      url = "{{ url_for('airflow.dag_success') }}" +
+        "?dag_id=" + encodeURIComponent(dag_id) +
         "&execution_date=" + execution_date +
         "&origin=" + encodeURIComponent(window.location);
 
@@ -365,6 +428,10 @@ function updateQueryStringParameter(uri, key, value) {
       }
       url = "{{ url_for('airflow.paused') }}" + '?is_paused=' + is_paused + '&dag_id=' + dag_id;
       $.post(url);
+    });
+
+    $('#btn_edit_dag').click(function(){
+      window.location = '/admin/dagrun/edit/?id=' + id;
     });
 
   </script>

--- a/airflow/www/templates/airflow/tree.html
+++ b/airflow/www/templates/airflow/tree.html
@@ -1,13 +1,13 @@
-{# 
+{#
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
   this work for additional information regarding copyright ownership.
   The ASF licenses this file to You under the Apache License, Version 2.0
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
-  
+
     http://www.apache.org/licenses/LICENSE-2.0
-  
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -232,9 +232,8 @@ function update(source) {
       .enter()
       .append('rect')
       .on("click", function(d){
-        if(d.task_id === undefined){
-          window.location = '/admin/dagrun/edit/?id=' + d.id;
-        }
+        if(d.task_id === undefined)
+            call_modal_dag(d);
         else if(nodeobj[d.task_id].operator=='SubDagOperator')
             call_modal(d.task_id, d.execution_date, true);
         else

--- a/tests/api/common/mark_tasks.py
+++ b/tests/api/common/mark_tasks.py
@@ -16,11 +16,12 @@
 import unittest
 
 from airflow import models
-from airflow.api.common.experimental.mark_tasks import set_state, _create_dagruns
+from airflow.api.common.experimental.mark_tasks import (
+    set_state, _create_dagruns, set_dag_state)
 from airflow.settings import Session
 from airflow.utils.dates import days_ago
 from airflow.utils.state import State
-
+from datetime import datetime, timedelta
 
 DEV_NULL = "/dev/null"
 
@@ -206,6 +207,190 @@ class TestMarkTasks(unittest.TestCase):
         self.session.commit()
 
         self.session.close()
+
+class TestMarkDAG(unittest.TestCase):
+    def setUp(self):
+        self.dagbag = models.DagBag(include_examples=True)
+        self.dag1 = self.dagbag.dags['test_example_bash_operator']
+        self.dag2 = self.dagbag.dags['example_subdag_operator']
+
+        self.execution_dates = [days_ago(3), days_ago(2), days_ago(1)]
+
+        self.session = Session()
+
+    def verify_dag_states(self, dag, date, state=State.SUCCESS):
+        drs = models.DagRun.find(dag_id=dag.dag_id, execution_date=date)
+        dr = drs[0]
+        self.assertEqual(dr.get_state(), state)
+        tis = dr.get_task_instances(session=self.session)
+        for ti in tis:
+            self.assertEqual(ti.state, state)
+
+    def test_set_running_dag_state(self):
+        date = self.execution_dates[0]
+        dr = self.dag1.create_dagrun(
+            run_id='manual__' + datetime.now().isoformat(),
+            state=State.RUNNING,
+            execution_date=date,
+            session=self.session
+        )
+        for ti in dr.get_task_instances(session=self.session):
+            ti.set_state(State.RUNNING, self.session)
+
+        altered = set_dag_state(self.dag1, date, state=State.SUCCESS, commit=True)
+
+        # All of the task should be altered
+        self.assertEqual(len(altered), len(self.dag1.tasks))
+        self.verify_dag_states(self.dag1, date)
+
+    def test_set_success_dag_state(self):
+        date = self.execution_dates[0]
+
+        dr = self.dag1.create_dagrun(
+            run_id='manual__' + datetime.now().isoformat(),
+            state=State.SUCCESS,
+            execution_date=date,
+            session=self.session
+        )
+        for ti in dr.get_task_instances(session=self.session):
+            ti.set_state(State.SUCCESS, self.session)
+
+        altered = set_dag_state(self.dag1, date, state=State.SUCCESS, commit=True)
+
+        # None of the task should be altered
+        self.assertEqual(len(altered), 0)
+        self.verify_dag_states(self.dag1, date)
+
+    def test_set_failed_dag_state(self):
+        date = self.execution_dates[0]
+        dr = self.dag1.create_dagrun(
+            run_id='manual__' + datetime.now().isoformat(),
+            state=State.FAILED,
+            execution_date=date,
+            session=self.session
+        )
+        dr.get_task_instance('runme_0').set_state(State.FAILED, self.session)
+
+        altered = set_dag_state(self.dag1, date, state=State.SUCCESS, commit=True)
+
+        # All of the task should be altered
+        self.assertEqual(len(altered), len(self.dag1.tasks))
+        self.verify_dag_states(self.dag1, date)
+
+    def test_set_mixed_dag_state(self):
+        """
+        This test checks function set_dag_state with mixed task instance
+        state.
+        """
+        date = self.execution_dates[0]
+        dr = self.dag1.create_dagrun(
+            run_id='manual__' + datetime.now().isoformat(),
+            state=State.FAILED,
+            execution_date=date,
+            session=self.session
+        )
+        # success task
+        dr.get_task_instance('runme_0').set_state(State.SUCCESS, self.session)
+        # skipped task
+        dr.get_task_instance('runme_1').set_state(State.SKIPPED, self.session)
+        # retry task
+        dr.get_task_instance('runme_2').set_state(State.UP_FOR_RETRY, self.session)
+        # queued task
+        dr.get_task_instance('also_run_this').set_state(State.QUEUED, self.session)
+        # running task
+        dr.get_task_instance('run_after_loop').set_state(State.RUNNING, self.session)
+        # failed task
+        dr.get_task_instance('run_this_last').set_state(State.FAILED, self.session)
+
+        altered = set_dag_state(self.dag1, date, state=State.SUCCESS, commit=True)
+
+        self.assertEqual(len(altered), len(self.dag1.tasks) - 1) # only 1 task succeeded
+        self.verify_dag_states(self.dag1, date)
+
+    def test_set_state_without_commit(self):
+        date = self.execution_dates[0]
+
+        # Running dag run and task instances
+        dr = self.dag1.create_dagrun(
+            run_id='manual__' + datetime.now().isoformat(),
+            state=State.RUNNING,
+            execution_date=date,
+            session=self.session
+        )
+        for ti in dr.get_task_instances(session=self.session):
+            ti.set_state(State.RUNNING, self.session)
+
+        altered = set_dag_state(self.dag1, date, state=State.SUCCESS, commit=False)
+
+        # All of the task should be altered
+        self.assertEqual(len(altered), len(self.dag1.tasks))
+
+        # Both dag run and task instances' states should remain the same
+        self.verify_dag_states(self.dag1, date, State.RUNNING)
+
+    def test_set_state_with_multiple_dagruns(self):
+        dr1 = self.dag2.create_dagrun(
+            run_id='manual__' + datetime.now().isoformat(),
+            state=State.FAILED,
+            execution_date=self.execution_dates[0],
+            session=self.session
+        )
+        dr2 = self.dag2.create_dagrun(
+            run_id='manual__' + datetime.now().isoformat(),
+            state=State.FAILED,
+            execution_date=self.execution_dates[1],
+            session=self.session
+        )
+        dr3 = self.dag2.create_dagrun(
+            run_id='manual__' + datetime.now().isoformat(),
+            state=State.RUNNING,
+            execution_date=self.execution_dates[2],
+            session=self.session
+        )
+
+        altered = set_dag_state(self.dag2, self.execution_dates[1],
+                                state=State.SUCCESS, commit=True)
+
+        # Recursively count number of tasks in the dag
+        def count_dag_tasks(dag):
+            count = len(dag.tasks)
+            subdag_counts = [count_dag_tasks(subdag) for subdag in dag.subdags]
+            count += sum(subdag_counts)
+            return count
+
+        self.assertEqual(len(altered), count_dag_tasks(self.dag2))
+        self.verify_dag_states(self.dag2, self.execution_dates[1])
+
+        # Make sure other dag status are not changed
+        dr1 = models.DagRun.find(dag_id=self.dag2.dag_id, execution_date=self.execution_dates[0])
+        dr1 = dr1[0]
+        self.assertEqual(dr1.get_state(), State.FAILED)
+        dr3 = models.DagRun.find(dag_id=self.dag2.dag_id, execution_date=self.execution_dates[2])
+        dr3 = dr3[0]
+        self.assertEqual(dr3.get_state(), State.RUNNING)
+
+    def test_set_dag_state_edge_cases(self):
+        # Dag does not exist
+        altered = set_dag_state(None, self.execution_dates[0])
+        self.assertEqual(len(altered), 0)
+
+        # Invalid execution date
+        altered = set_dag_state(self.dag1, None)
+        self.assertEqual(len(altered), 0)
+        self.assertRaises(AssertionError, set_dag_state, self.dag1, timedelta(microseconds=-1))
+
+        # DagRun does not exist
+        # This will throw AssertionError since dag.latest_execution_date does not exist
+        self.assertRaises(AssertionError, set_dag_state, self.dag1, self.execution_dates[0])
+
+    def tearDown(self):
+        self.dag1.clear()
+        self.dag2.clear()
+
+        self.session.query(models.DagRun).delete()
+        self.session.query(models.TaskInstance).delete()
+        self.session.query(models.DagStat).delete()
+        self.session.commit()
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses [Airflow 936](https://issues.apache.org/jira/browse/AIRFLOW-936) issues and references them in the PR title. 

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

This PR adds a modal popup when clicking circle DAG icon in Airflow tree view UI. It adds the functionalities to clear/mark success of the entire DAG run. This behavior is equivalent to individually clear/mark each task instance in the DAG run. The original logic of editing DAG run page is moved to the button "Edit DAG Run".

![screen shot 2017-06-01 at 10 41 54 am](https://cloud.githubusercontent.com/assets/5182499/26692995/812d4ef8-46b7-11e7-8820-25f450f952c1.png)
![screen shot 2017-06-01 at 10 42 14 am](https://cloud.githubusercontent.com/assets/5182499/26693003/8c355188-46b7-11e7-910f-bf1e09bf4418.png)

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

 Tests are added under `test/api/common/mark_tasks.py` to test marking entire DAG as success. There is no test for clear the DAG since it is directly implemented in `views.py`.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

